### PR TITLE
Update readinessProbe in Deployment

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -34,3 +34,6 @@ spec:
               path: /health
               port: http
           readinessProbe:
+            httpGet:
+              path: /health
+              port: http


### PR DESCRIPTION
## Summary
- set up readiness probe to match liveness probe

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fyodorov_utils')*

------
https://chatgpt.com/codex/tasks/task_e_6841eebccc4883259948a1a9643e005b