### PR TITLE
Fix SDK names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Authorization: Bearer <YOUR_JWT>
 If you are planning to serve an API as a tool in Tsiolkovsky into your stack, you can use one of the following SDKs:
 
 - Python - coming soon!
-- Typescript - coming soon!
-- Javascript - coming soon!
+- TypeScript - coming soon!
+- JavaScript - coming soon!
 
 
 ## 🫶 Contributions:


### PR DESCRIPTION
## Summary
- fix capitalization of TypeScript and JavaScript in README

## Testing
- `pip install -r src/requirements.txt -r src/requirements-test.txt`
- `pytest -q` *(fails: ModuleNotFoundError for `fyodorov_utils`)*

------
https://chatgpt.com/codex/tasks/task_e_6841eeb799c48325b8f9935b4670aa06